### PR TITLE
Add pipeline configurations

### DIFF
--- a/configurations/code_imputation_functions.py
+++ b/configurations/code_imputation_functions.py
@@ -1,0 +1,57 @@
+import time
+
+from core_data_modules.cleaners import Codes
+from core_data_modules.cleaners.cleaning_utils import CleaningUtils
+from core_data_modules.data_models.code_scheme import CodeTypes
+from core_data_modules.traced_data import Metadata
+
+
+def make_location_code(scheme, clean_value):
+    if clean_value == Codes.NOT_CODED:
+        return scheme.get_code_with_control_code(Codes.NOT_CODED)
+    else:
+        return scheme.get_code_with_match_value(clean_value)
+
+def impute_age_category(user, data, age_configurations):
+    # TODO: By accepting a list of age_configurations but then requiring that list to contain code schemes in a
+    #       certain order, it looks like we're providing more flexibility than we actually do. We should change this
+    #       to explicitly accept age and age_category configurations, which requires refactoring all of the
+    #       code imputation functions.
+    age_cc = age_configurations[0]
+    age_category_cc = age_configurations[1]
+
+    age_categories = {
+        (10, 14): "10 to 14",
+        (15, 17): "15 to 17",
+        (18, 35): "18 to 35",
+        (36, 54): "36 to 54",
+        (55, 99): "55 to 99"
+    }
+
+    for td in data:
+        age_label = td[age_cc.coded_field]
+        age_code = age_cc.code_scheme.get_code_with_code_id(age_label["CodeID"])
+
+        if age_code.code_type == CodeTypes.NORMAL:
+            # TODO: If these age categories are standard across projects, move this to Core as a new cleaner.
+            age_category = None
+            for age_range, category in age_categories.items():
+                if age_range[0] <= age_code.numeric_value <= age_range[1]:
+                    age_category = category
+            assert age_category is not None
+
+            age_category_code = age_category_cc.code_scheme.get_code_with_match_value(age_category)
+        elif age_code.code_type == CodeTypes.META:
+            age_category_code = age_category_cc.code_scheme.get_code_with_meta_code(age_code.meta_code)
+        else:
+            assert age_code.code_type == CodeTypes.CONTROL
+            age_category_code = age_category_cc.code_scheme.get_code_with_control_code(age_code.control_code)
+
+        age_category_label = CleaningUtils.make_label_from_cleaner_code(
+            age_category_cc.code_scheme, age_category_code, Metadata.get_call_location()
+        )
+
+        td.append_data(
+            {age_category_cc.coded_field: age_category_label.to_dict()},
+            Metadata(user, Metadata.get_call_location(), time.time())
+        )

--- a/configurations/code_schemes.py
+++ b/configurations/code_schemes.py
@@ -1,0 +1,46 @@
+import json
+
+from core_data_modules.data_models import CodeScheme
+
+
+def _open_scheme(filename):
+    with open(f"code_schemes/{filename}", "r") as f:
+        firebase_map = json.load(f)
+        return CodeScheme.from_firebase_map(firebase_map)
+
+
+class CodeSchemes(object):
+    DADAAB_S01E01 = _open_scheme("dadaab_s01e01.json")
+    DADAAB_S01E02 = _open_scheme("dadaab_s01e02.json")
+    DADAAB_S01E03 = _open_scheme("dadaab_s01e03.json")
+    DADAAB_S01E04 = _open_scheme("dadaab_s01e04.json")
+    DADAAB_S01E05 = _open_scheme("dadaab_s01e05.json")
+    DADAAB_S01E06 = _open_scheme("dadaab_s01e06.json")
+    DADAAB_S01E07 = _open_scheme("dadaab_s01e07.json")
+    DADAAB_S01E08 = _open_scheme("dadaab_s01e08.json")
+    DADAAB_S01E09 = _open_scheme("dadaab_s01e09.json")
+    DADAAB_S01E10 = _open_scheme("dadaab_s01e10.json")
+
+    KAKUMA_S01E01 = _open_scheme("kakuma_s01e01.json")
+    KAKUMA_S01E02 = _open_scheme("kakuma_s01e02.json")
+    KAKUMA_S01E03 = _open_scheme("kakuma_s01e03.json")
+    KAKUMA_S01E04 = _open_scheme("kakuma_s01e04.json")
+    KAKUMA_S01E05 = _open_scheme("kakuma_s01e05.json")
+    KAKUMA_S01E06 = _open_scheme("kakuma_s01e06.json")
+    KAKUMA_S01E07 = _open_scheme("kakuma_s01e07.json")
+    KAKUMA_S01E08 = _open_scheme("kakuma_s01e08.json")
+    KAKUMA_S01E09 = _open_scheme("kakuma_s01e09.json")
+    KAKUMA_S01E10 = _open_scheme("kakuma_s01e10.json")
+
+    GENDER = _open_scheme("gender.json")
+    NATIONALITY = _open_scheme("nationality.json")
+    AGE = _open_scheme("age.json")
+    AGE_CATEGORY = _open_scheme("age_category.json")
+    DADAAB_HOUSEHOLD_LANGUAGE = _open_scheme("dadaab_household_language.json") # We have different language & location schemes for the two camps
+    DADAAB_LOCATION = _open_scheme("dadaab_location.json")
+    KAKUMA_HOUSEHOLD_LANGUAGE = _open_scheme("kakuma_household_language.json")
+    KAKUMA_LOCATION = _open_scheme("kakuma_location.json")
+
+    WS_CORRECT_DATASET_SCHEME = None
+    KAKUMA_WS_CORRECT_DATASET_SCHEME = _open_scheme("kakuma_ws_correct_dataset.json")
+    DADAAB_WS_CORRECT_DATASET_SCHEME = _open_scheme("dadaab_ws_correct_dataset.json")

--- a/configurations/dadaab_pipeline_config.json
+++ b/configurations/dadaab_pipeline_config.json
@@ -1,0 +1,101 @@
+{
+  "RawDataSources": [
+    {
+      "SourceType": "RapidPro",
+      "Domain": "textit.in",
+      "TokenFileURL": "gs://avf-credentials/wusc-keep-II-dadaab-textit-token.txt",
+      "ContactsFileName": "wusc_dadaab_contacts",
+      "ActivationFlowNames": [
+        "wusc_covid19_adaptation_s01e01_dadaab_activation"
+      ],
+      "SurveyFlowNames": [
+        "wusc_keep_ii_dadaab_demogs",
+        "wusc_covid19_adaptation_kakuma_demogs"
+      ],
+      "TestContactUUIDs": [
+        "f3e07a4a-4c5d-4032-80f3-c31bcf480dc9",
+        "8aa09c45-5070-4a75-a3b8-75d8519e77b9",
+        "33d8b0c6-4b68-4307-b7ae-0088024b380d",
+        "9c8bc1e6-78bc-40ac-8b11-aec4280b3862",
+        "415bd689-bb41-44f9-90af-8e743cfca35b"
+      ]
+    }
+  ],
+  "PhoneNumberUuidTable": {
+    "FirebaseCredentialsFileURL": "gs://avf-credentials/avf-id-infrastructure-firebase-adminsdk-6xps8-b9173f2bfd.json",
+    "TableName": "WUSC_KEEP_II_phone_number_avf_phone_id"
+  },
+  "RapidProKeyRemappings": [
+    {"RapidProKey": "avf_phone_id", "PipelineKey": "uid"},
+    {"RapidProKey": "Rqa_Adaptation_S01E01_Dadaab (Text) - wusc_covid19_adaptation_s01e01_dadaab_activation", "PipelineKey": "rqa_s01e01_raw", "IsActivationMessage": true},
+    {"RapidProKey": "Rqa_Adaptation_S01E02_Dadaab (Text) - wusc_covid19_adaptation_s01e02_dadaab_activation", "PipelineKey": "rqa_s01e02_raw", "IsActivationMessage": true},
+    {"RapidProKey": "Rqa_Adaptation_S01E03_Dadaab (Text) - wusc_covid19_adaptation_s01e03_dadaab_activation", "PipelineKey": "rqa_s01e03_raw", "IsActivationMessage": true},
+    {"RapidProKey": "Rqa_Adaptation_S01E04_Dadaab (Text) - wusc_covid19_adaptation_s01e04_dadaab_activation", "PipelineKey": "rqa_s01e04_raw", "IsActivationMessage": true},
+    {"RapidProKey": "Rqa_Adaptation_S01E05_Dadaab (Text) - wusc_covid19_adaptation_s01e05_dadaab_activation", "PipelineKey": "rqa_s01e05_raw", "IsActivationMessage": true},
+    {"RapidProKey": "Rqa_Adaptation_S01E06_Dadaab (Text) - wusc_covid19_adaptation_s01e06_dadaab_activation", "PipelineKey": "rqa_s01e06_raw", "IsActivationMessage": true},
+    {"RapidProKey": "Rqa_Adaptation_S01E07_Dadaab (Text) - wusc_covid19_adaptation_s01e07_dadaab_activation", "PipelineKey": "rqa_s01e07_raw", "IsActivationMessage": true},
+    {"RapidProKey": "Rqa_Adaptation_S01E08_Dadaab (Text) - wusc_covid19_adaptation_s01e08_dadaab_activation", "PipelineKey": "rqa_s01e08_raw", "IsActivationMessage": true},
+    {"RapidProKey": "Rqa_Adaptation_S01E09_Dadaab (Text) - wusc_covid19_adaptation_s01e09_dadaab_activation", "PipelineKey": "rqa_s01e09_raw", "IsActivationMessage": true},
+    {"RapidProKey": "Rqa_Adaptation_S01E10_Dadaab (Text) - wusc_covid19_adaptation_s01e10_dadaab_activation", "PipelineKey": "rqa_s01e10_raw", "IsActivationMessage": true},
+
+    {"RapidProKey": "Rqa_Adaptation_S01E01_Dadaab (Run ID) - wusc_covid19_adaptation_s01e01_dadaab_activation", "PipelineKey": "rqa_s01e01_run_id"},
+    {"RapidProKey": "Rqa_Adaptation_S01E02_Dadaab (Run ID) - wusc_covid19_adaptation_s01e02_dadaab_activation", "PipelineKey": "rqa_s01e02_run_id"},
+    {"RapidProKey": "Rqa_Adaptation_S01E03_Dadaab (Run ID) - wusc_covid19_adaptation_s01e03_dadaab_activation", "PipelineKey": "rqa_s01e03_run_id"},
+    {"RapidProKey": "Rqa_Adaptation_S01E04_Dadaab (Run ID) - wusc_covid19_adaptation_s01e04_dadaab_activation", "PipelineKey": "rqa_s01e04_run_id"},
+    {"RapidProKey": "Rqa_Adaptation_S01E05_Dadaab (Run ID) - wusc_covid19_adaptation_s01e05_dadaab_activation", "PipelineKey": "rqa_s01e05_run_id"},
+    {"RapidProKey": "Rqa_Adaptation_S01E06_Dadaab (Run ID) - wusc_covid19_adaptation_s01e06_dadaab_activation", "PipelineKey": "rqa_s01e06_run_id"},
+    {"RapidProKey": "Rqa_Adaptation_S01E07_Dadaab (Run ID) - wusc_covid19_adaptation_s01e07_dadaab_activation", "PipelineKey": "rqa_s01e07_run_id"},
+    {"RapidProKey": "Rqa_Adaptation_S01E08_Dadaab (Run ID) - wusc_covid19_adaptation_s01e08_dadaab_activation", "PipelineKey": "rqa_s01e08_run_id"},
+    {"RapidProKey": "Rqa_Adaptation_S01E09_Dadaab (Run ID) - wusc_covid19_adaptation_s01e09_dadaab_activation", "PipelineKey": "rqa_s01e09_run_id"},
+    {"RapidProKey": "Rqa_Adaptation_S01E10_Dadaab (Run ID) - wusc_covid19_adaptation_s01e10_dadaab_activation", "PipelineKey": "rqa_s01e10_run_id"},
+
+    {"RapidProKey": "Rqa_Adaptation_S01E01_Dadaab (Time) - wusc_covid19_adaptation_s01e01_dadaab_activation", "PipelineKey": "sent_on"},
+    {"RapidProKey": "Rqa_Adaptation_S01E02_Dadaab (Time) - wusc_covid19_adaptation_s01e02_dadaab_activation", "PipelineKey": "sent_on"},
+    {"RapidProKey": "Rqa_Adaptation_S01E03_Dadaab (Time) - wusc_covid19_adaptation_s01e03_dadaab_activation", "PipelineKey": "sent_on"},
+    {"RapidProKey": "Rqa_Adaptation_S01E04_Dadaab (Time) - wusc_covid19_adaptation_s01e04_dadaab_activation", "PipelineKey": "sent_on"},
+    {"RapidProKey": "Rqa_Adaptation_S01E05_Dadaab (Time) - wusc_covid19_adaptation_s01e05_dadaab_activation", "PipelineKey": "sent_on"},
+    {"RapidProKey": "Rqa_Adaptation_S01E06_Dadaab (Time) - wusc_covid19_adaptation_s01e06_dadaab_activation", "PipelineKey": "sent_on"},
+    {"RapidProKey": "Rqa_Adaptation_S01E07_Dadaab (Time) - wusc_covid19_adaptation_s01e07_dadaab_activation", "PipelineKey": "sent_on"},
+    {"RapidProKey": "Rqa_Adaptation_S01E08_Dadaab (Time) - wusc_covid19_adaptation_s01e08_dadaab_activation", "PipelineKey": "sent_on"},
+    {"RapidProKey": "Rqa_Adaptation_S01E09_Dadaab (Time) - wusc_covid19_adaptation_s01e09_dadaab_activation", "PipelineKey": "sent_on"},
+    {"RapidProKey": "Rqa_Adaptation_S01E10_Dadaab (Time) - wusc_covid19_adaptation_s01e10_dadaab_activation", "PipelineKey": "sent_on"},
+
+    {"RapidProKey": "Gender (Text) - wusc_keep_ii_dadaab_demogs", "PipelineKey": "gender_raw"},
+    {"RapidProKey": "Age (Text) - wusc_keep_ii_dadaab_demogs", "PipelineKey": "age_raw"},
+    {"RapidProKey": "Location (Text) - wusc_keep_ii_dadaab_demogs", "PipelineKey": "location_raw"},
+    {"RapidProKey": "Nationality (Text) - wusc_keep_ii_dadaab_demogs", "PipelineKey": "nationality_raw"},
+    {"RapidProKey": "Household_Language (Text) - wusc_keep_ii_dadaab_demogs", "PipelineKey": "household_language_raw"},
+
+    {"RapidProKey": "Gender (Time) - wusc_keep_ii_dadaab_demogs", "PipelineKey": "gender_time"},
+    {"RapidProKey": "Age (Time) - wusc_keep_ii_dadaab_demogs", "PipelineKey": "age_time"},
+    {"RapidProKey": "Location (Time) - wusc_keep_ii_dadaab_demogs", "PipelineKey": "location_time"},
+    {"RapidProKey": "Nationality (Time) - wusc_keep_ii_dadaab_demogs", "PipelineKey": "nationality_time"},
+    {"RapidProKey": "Household_Language (Time) - wusc_keep_ii_dadaab_demogs", "PipelineKey": "household_language_time"},
+    
+    {"RapidProKey": "Gender (Text) - wusc_covid19_adaptation_dadaab_demogs", "PipelineKey": "gender_raw"},
+    {"RapidProKey": "Age (Text) - wusc_covid19_adaptation_dadaab_demogs", "PipelineKey": "age_raw"},
+    {"RapidProKey": "Location (Text) - wusc_covid19_adaptation_dadaab_demogs", "PipelineKey": "location_raw"},
+    {"RapidProKey": "Nationality (Text) - wusc_covid19_adaptation_dadaab_demogs", "PipelineKey": "nationality_raw"},
+    {"RapidProKey": "Household_Language (Text) - wusc_covid19_adaptation_dadaab_demogs", "PipelineKey": "household_language_raw"},
+
+    {"RapidProKey": "Gender (Time) - wusc_covid19_adaptation_dadaab_demogs", "PipelineKey": "gender_time"},
+    {"RapidProKey": "Age (Time) - wusc_covid19_adaptation_dadaab_demogs", "PipelineKey": "age_time"},
+    {"RapidProKey": "Location (Time) - wusc_covid19_adaptation_dadaab_demogs", "PipelineKey": "location_time"},
+    {"RapidProKey": "Nationality (Time) - wusc_covid19_adaptation_dadaab_demogs", "PipelineKey": "nationality_time"},
+    {"RapidProKey": "Household_Language (Time) - wusc_covid19_adaptation_dadaab_demogs", "PipelineKey": "household_language_time"}
+  ],
+  "PipelineName": "dadaab_pipeline",
+  "ProjectStartDate": "2020-05-06T08:20:00+03:00",
+  "ProjectEndDate": "2100-01-01T00:00:00+03:00",
+  "FilterTestMessages": true,
+  "MoveWSMessages": false,
+ "DriveUpload": {
+    "DriveCredentialsFileURL": "gs://avf-credentials/pipeline-runner-service-acct-avf-data-core-64cc71459fe7.json",
+    "ProductionUploadPath": "wusc_covid19_adaptation_analysis_outputs/dadaab/wusc_covid19_adaptation_s01_dadaab_production.csv",
+    "MessagesUploadPath": "wusc_covid19_adaptation_analysis_outputs/dadaab/wusc_covid19_adaptation_s01_dadaab_messages.csv",
+    "IndividualsUploadPath": "wusc_covid19_adaptation_analysis_outputs/dadaab/wusc_covid19_adaptation_s01_dadaab_individuals.csv",
+    "AutomatedAnalysisDir": "wusc_covid19_adaptation_analysis_outputs/dadaab/automated_analysis"
+  },
+  "MemoryProfileUploadURLPrefix": "gs://avf-pipeline-logs-performance-nearline/2020/WUSC-COVID19-ADAPTATION/dadaab-memory-",
+  "DataArchiveUploadURLPrefix": "gs://pipeline-execution-backup-archive/2020/WUSC-COVID19-ADAPTATION/dadaab-data-"
+}

--- a/configurations/docker_image_project_name.txt
+++ b/configurations/docker_image_project_name.txt
@@ -1,0 +1,1 @@
+wusc-covid19-adaptation

--- a/configurations/kakuma_pipeline_config.json
+++ b/configurations/kakuma_pipeline_config.json
@@ -1,0 +1,100 @@
+{
+  "RawDataSources": [
+    {
+      "SourceType": "RapidPro",
+      "Domain": "textit.in",
+      "TokenFileURL": "gs://avf-credentials/wusc-keep-II-kakuma-textit-token.txt",
+      "ContactsFileName": "wusc_kakuma_contacts",
+      "ActivationFlowNames": [
+        "wusc_covid19_adaptation_s01e01_kakuma_activation"
+      ],
+      "SurveyFlowNames": [
+        "wusc_keep_ii_kakuma_demogs",
+        "wusc_covid19_adaptation_kakuma_demogs"
+      ],
+      "TestContactUUIDs": [
+        "84f1c3bc-596e-455e-b5f6-ce16640e9b95",
+        "965a6702-08b9-438d-b234-d2d71b5e7c27",
+        "5f214693-03dc-4867-b440-896bf2ccbb1e",
+        "df4b5e80-2148-4fa6-82c1-307bebc554bc"
+      ]
+    }
+  ],
+  "PhoneNumberUuidTable": {
+    "FirebaseCredentialsFileURL": "gs://avf-credentials/avf-id-infrastructure-firebase-adminsdk-6xps8-b9173f2bfd.json",
+    "TableName": "WUSC_KEEP_II_phone_number_avf_phone_id"
+  },
+  "RapidProKeyRemappings": [
+    {"RapidProKey": "avf_phone_id", "PipelineKey": "uid"},
+    {"RapidProKey": "Rqa_Adaptation_S01E01_Kakuma (Text) - wusc_covid19_adaptation_s01e01_kakuma_activation", "PipelineKey": "rqa_s01e01_raw", "IsActivationMessage": true},
+    {"RapidProKey": "Rqa_Adaptation_S01E02_Kakuma (Text) - wusc_covid19_adaptation_s01e02_kakuma_activation", "PipelineKey": "rqa_s01e02_raw", "IsActivationMessage": true},
+    {"RapidProKey": "Rqa_Adaptation_S01E03_Kakuma (Text) - wusc_covid19_adaptation_s01e03_kakuma_activation", "PipelineKey": "rqa_s01e03_raw", "IsActivationMessage": true},
+    {"RapidProKey": "Rqa_Adaptation_S01E04_Kakuma (Text) - wusc_covid19_adaptation_s01e04_kakuma_activation", "PipelineKey": "rqa_s01e04_raw", "IsActivationMessage": true},
+    {"RapidProKey": "Rqa_Adaptation_S01E05_Kakuma (Text) - wusc_covid19_adaptation_s01e05_kakuma_activation", "PipelineKey": "rqa_s01e05_raw", "IsActivationMessage": true},
+    {"RapidProKey": "Rqa_Adaptation_S01E06_Kakuma (Text) - wusc_covid19_adaptation_s01e06_kakuma_activation", "PipelineKey": "rqa_s01e06_raw", "IsActivationMessage": true},
+    {"RapidProKey": "Rqa_Adaptation_S01E07_Kakuma (Text) - wusc_covid19_adaptation_s01e07_kakuma_activation", "PipelineKey": "rqa_s01e07_raw", "IsActivationMessage": true},
+    {"RapidProKey": "Rqa_Adaptation_S01E08_Kakuma (Text) - wusc_covid19_adaptation_s01e08_kakuma_activation", "PipelineKey": "rqa_s01e08_raw", "IsActivationMessage": true},
+    {"RapidProKey": "Rqa_Adaptation_S01E09_Kakuma (Text) - wusc_covid19_adaptation_s01e09_kakuma_activation", "PipelineKey": "rqa_s01e09_raw", "IsActivationMessage": true},
+    {"RapidProKey": "Rqa_Adaptation_S01E10_Kakuma (Text) - wusc_covid19_adaptation_s01e10_kakuma_activation", "PipelineKey": "rqa_s01e10_raw", "IsActivationMessage": true},
+
+    {"RapidProKey": "Rqa_Adaptation_S01E01_Kakuma (Run ID) - wusc_covid19_adaptation_s01e01_kakuma_activation", "PipelineKey": "rqa_s01e01_run_id"},
+    {"RapidProKey": "Rqa_Adaptation_S01E02_Kakuma (Run ID) - wusc_covid19_adaptation_s01e02_kakuma_activation", "PipelineKey": "rqa_s01e02_run_id"},
+    {"RapidProKey": "Rqa_Adaptation_S01E03_Kakuma (Run ID) - wusc_covid19_adaptation_s01e03_kakuma_activation", "PipelineKey": "rqa_s01e03_run_id"},
+    {"RapidProKey": "Rqa_Adaptation_S01E04_Kakuma (Run ID) - wusc_covid19_adaptation_s01e04_kakuma_activation", "PipelineKey": "rqa_s01e04_run_id"},
+    {"RapidProKey": "Rqa_Adaptation_S01E05_Kakuma (Run ID) - wusc_covid19_adaptation_s01e05_kakuma_activation", "PipelineKey": "rqa_s01e05_run_id"},
+    {"RapidProKey": "Rqa_Adaptation_S01E06_Kakuma (Run ID) - wusc_covid19_adaptation_s01e06_kakuma_activation", "PipelineKey": "rqa_s01e06_run_id"},
+    {"RapidProKey": "Rqa_Adaptation_S01E07_Kakuma (Run ID) - wusc_covid19_adaptation_s01e07_kakuma_activation", "PipelineKey": "rqa_s01e07_run_id"},
+    {"RapidProKey": "Rqa_Adaptation_S01E08_Kakuma (Run ID) - wusc_covid19_adaptation_s01e08_kakuma_activation", "PipelineKey": "rqa_s01e08_run_id"},
+    {"RapidProKey": "Rqa_Adaptation_S01E09_Kakuma (Run ID) - wusc_covid19_adaptation_s01e09_kakuma_activation", "PipelineKey": "rqa_s01e09_run_id"},
+    {"RapidProKey": "Rqa_Adaptation_S01E10_Kakuma (Run ID) - wusc_covid19_adaptation_s01e10_kakuma_activation", "PipelineKey": "rqa_s01e10_run_id"},
+
+    {"RapidProKey": "Rqa_Adaptation_S01E01_Kakuma (Time) - wusc_covid19_adaptation_s01e01_kakuma_activation", "PipelineKey": "sent_on"},
+    {"RapidProKey": "Rqa_Adaptation_S01E02_Kakuma (Time) - wusc_covid19_adaptation_s01e02_kakuma_activation", "PipelineKey": "sent_on"},
+    {"RapidProKey": "Rqa_Adaptation_S01E03_Kakuma (Time) - wusc_covid19_adaptation_s01e03_kakuma_activation", "PipelineKey": "sent_on"},
+    {"RapidProKey": "Rqa_Adaptation_S01E04_Kakuma (Time) - wusc_covid19_adaptation_s01e04_kakuma_activation", "PipelineKey": "sent_on"},
+    {"RapidProKey": "Rqa_Adaptation_S01E05_Kakuma (Time) - wusc_covid19_adaptation_s01e05_kakuma_activation", "PipelineKey": "sent_on"},
+    {"RapidProKey": "Rqa_Adaptation_S01E06_Kakuma (Time) - wusc_covid19_adaptation_s01e06_kakuma_activation", "PipelineKey": "sent_on"},
+    {"RapidProKey": "Rqa_Adaptation_S01E07_Kakuma (Time) - wusc_covid19_adaptation_s01e07_kakuma_activation", "PipelineKey": "sent_on"},
+    {"RapidProKey": "Rqa_Adaptation_S01E08_Kakuma (Time) - wusc_covid19_adaptation_s01e08_kakuma_activation", "PipelineKey": "sent_on"},
+    {"RapidProKey": "Rqa_Adaptation_S01E09_Kakuma (Time) - wusc_covid19_adaptation_s01e09_kakuma_activation", "PipelineKey": "sent_on"},
+    {"RapidProKey": "Rqa_Adaptation_S01E10_Kakuma (Time) - wusc_covid19_adaptation_s01e10_kakuma_activation", "PipelineKey": "sent_on"},
+
+    {"RapidProKey": "Gender (Text) - wusc_keep_ii_kakuma_demogs", "PipelineKey": "gender_raw"},
+    {"RapidProKey": "Age (Text) - wusc_keep_ii_kakuma_demogs", "PipelineKey": "age_raw"},
+    {"RapidProKey": "Location (Text) - wusc_keep_ii_kakuma_demogs", "PipelineKey": "location_raw"},
+    {"RapidProKey": "Nationality (Text) - wusc_keep_ii_kakuma_demogs", "PipelineKey": "nationality_raw"},
+    {"RapidProKey": "Household_Language (Text) - wusc_keep_ii_kakuma_demogs", "PipelineKey": "household_language_raw"},
+
+    {"RapidProKey": "Gender (Time) - wusc_keep_ii_kakuma_demogs", "PipelineKey": "gender_time"},
+    {"RapidProKey": "Age (Time) - wusc_keep_ii_kakuma_demogs", "PipelineKey": "age_time"},
+    {"RapidProKey": "Location (Time) - wusc_keep_ii_kakuma_demogs", "PipelineKey": "location_time"},
+    {"RapidProKey": "Nationality (Time) - wusc_keep_ii_kakuma_demogs", "PipelineKey": "nationality_time"},
+    {"RapidProKey": "Household_Language (Time) - wusc_keep_ii_kakuma_demogs", "PipelineKey": "household_language_time"},
+
+    {"RapidProKey": "Gender (Text) - wusc_covid19_adaptation_kakuma_demogs", "PipelineKey": "gender_raw"},
+    {"RapidProKey": "Age (Text) - wusc_covid19_adaptation_kakuma_demogs", "PipelineKey": "age_raw"},
+    {"RapidProKey": "Location (Text) - wusc_covid19_adaptation_kakuma_demogs", "PipelineKey": "location_raw"},
+    {"RapidProKey": "Nationality (Text) - wusc_covid19_adaptation_kakuma_demogs", "PipelineKey": "nationality_raw"},
+    {"RapidProKey": "Household_Language (Text) - wusc_covid19_adaptation_kakuma_demogs", "PipelineKey": "household_language_raw"},
+
+    {"RapidProKey": "Gender (Time) - wusc_covid19_adaptation_kakuma_demogs", "PipelineKey": "gender_time"},
+    {"RapidProKey": "Age (Time) - wusc_covid19_adaptation_kakuma_demogs", "PipelineKey": "age_time"},
+    {"RapidProKey": "Location (Time) - wusc_covid19_adaptation_kakuma_demogs", "PipelineKey": "location_time"},
+    {"RapidProKey": "Nationality (Time) - wusc_covid19_adaptation_kakuma_demogs", "PipelineKey": "nationality_time"},
+    {"RapidProKey": "Household_Language (Time) - wusc_covid19_adaptation_kakuma_demogs", "PipelineKey": "household_language_time"}
+  ],
+  "PipelineName": "kakuma_pipeline",
+  "ProjectStartDate": "2020-05-05T00:00:00+03:00",
+  "ProjectEndDate": "2100-01-01T00:00:00+03:00",
+  "FilterTestMessages": false,
+  "MoveWSMessages": false,
+  "DriveUpload": {
+    "DriveCredentialsFileURL": "gs://avf-credentials/pipeline-runner-service-acct-avf-data-core-64cc71459fe7.json",
+    "ProductionUploadPath": "wusc_covid19_adaptation_analysis_outputs/kakuma/wusc_covid19_adaptation_s01_kakuma_production.csv",
+    "MessagesUploadPath": "wusc_covid19_adaptation_analysis_outputs/kakuma/wusc_covid19_adaptation_s01_kakuma_messages.csv",
+    "IndividualsUploadPath": "wusc_covid19_adaptation_analysis_outputs/kakuma/wusc_covid19_adaptation_s01_kakuma_individuals.csv",
+    "AutomatedAnalysisDir": "wusc_covid19_adaptation_analysis_outputs/kakuma/automated_analysis"
+  },
+  "MemoryProfileUploadURLPrefix": "gs://avf-pipeline-logs-performance-nearline/2020/WUSC-COVID19-ADAPTATION/kakuma-memory-",
+  "DataArchiveUploadURLPrefix": "gs://pipeline-execution-backup-archive/2020/WUSC-COVID19-ADAPTATION/kakuma-data-"
+}

--- a/src/lib/__init__.py
+++ b/src/lib/__init__.py
@@ -1,3 +1,4 @@
 from .consent_utils import ConsentUtils
 from .icr_tools import ICRTools
 from .message_filters import MessageFilters
+from .pipeline_configuration import PipelineConfiguration

--- a/src/lib/pipeline_configuration.py
+++ b/src/lib/pipeline_configuration.py
@@ -1,0 +1,1039 @@
+import json
+from abc import ABC, abstractmethod
+from datetime import datetime
+from urllib.parse import urlparse
+
+import pytz
+from core_data_modules.cleaners import Codes, swahili, somali
+from core_data_modules.data_models import validators
+from core_data_modules.traced_data.util.fold_traced_data import FoldStrategies
+from dateutil.parser import isoparse
+
+from configurations import code_imputation_functions
+from configurations.code_schemes import CodeSchemes
+
+
+class CodingModes(object):
+    SINGLE = "SINGLE"
+    MULTIPLE = "MULTIPLE"
+
+
+class CodingConfiguration(object):
+    def __init__(self, coding_mode, code_scheme, coded_field, fold_strategy, analysis_file_key=None, cleaner=None):
+        assert coding_mode in {CodingModes.SINGLE, CodingModes.MULTIPLE}
+
+        self.coding_mode = coding_mode
+        self.code_scheme = code_scheme
+        self.coded_field = coded_field
+        self.analysis_file_key = analysis_file_key
+        self.fold_strategy = fold_strategy
+        self.cleaner = cleaner
+
+
+# TODO: Rename CodingPlan to something like DatasetConfiguration?
+class CodingPlan(object):
+    def __init__(self, raw_field, dataset_name, coding_configurations, raw_field_fold_strategy, coda_filename=None, ws_code=None,
+                 time_field=None, run_id_field=None, icr_filename=None, id_field=None, code_imputation_function=None,
+                 listening_group_filename=None,):
+        self.raw_field = raw_field
+        self.dataset_name = dataset_name
+        self.time_field = time_field
+        self.run_id_field = run_id_field
+        self.coda_filename = coda_filename
+        self.icr_filename = icr_filename
+        self.coding_configurations = coding_configurations
+        self.code_imputation_function = code_imputation_function
+        self.listening_group_filename = listening_group_filename
+        self.ws_code = ws_code
+        self.raw_field_fold_strategy = raw_field_fold_strategy
+
+        if id_field is None:
+            id_field = "{}_id".format(self.raw_field)
+        self.id_field = id_field
+
+
+class PipelineConfiguration(object):
+
+    RQA_CODING_PLANS = None
+
+    DADAAB_RQA_CODING_PLANS = [
+        CodingPlan(raw_field="rqa_s01e01_raw",
+                   dataset_name="dadaab_s01e01",
+                   time_field="sent_on",
+                   run_id_field="rqa_s01e01_run_id",
+                   coda_filename="dadaab_s01e01.json",
+                   icr_filename="dadaab_s01e01.csv",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.MULTIPLE,
+                           code_scheme=CodeSchemes.DADAAB_S01E01,
+                           coded_field="rqa_s01e01_coded",
+                           analysis_file_key="rqa_s01e01_",
+                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.DADAAB_S01E01, x, y)
+                       )
+                   ],
+                   ws_code=CodeSchemes.DADAAB_WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("covid19 adaptation dadaab s01e01"),
+                   raw_field_fold_strategy=FoldStrategies.concatenate),
+
+        CodingPlan(raw_field="rqa_s01e02_raw",
+                   dataset_name="dadaab_s01e02",
+                   time_field="sent_on",
+                   run_id_field="rqa_s01e02_run_id",
+                   coda_filename="dadaab_s01e02.json",
+                   icr_filename="dadaab_s01e02.csv",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.MULTIPLE,
+                           code_scheme=CodeSchemes.DADAAB_S01E02,
+                           coded_field="rqa_s01e02_coded",
+                           analysis_file_key="rqa_s01e02_",
+                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.DADAAB_S01E02, x, y)
+                       )
+                   ],
+                   ws_code=CodeSchemes.DADAAB_WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("covid19 adaptation dadaab s01e02"),
+                   raw_field_fold_strategy=FoldStrategies.concatenate),
+
+        CodingPlan(raw_field="rqa_s01e03_raw",
+                   dataset_name="dadaab_s01e03",
+                   time_field="sent_on",
+                   run_id_field="rqa_s01e03_run_id",
+                   coda_filename="dadaab_s01e03.json",
+                   icr_filename="dadaab_s01e03.csv",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.MULTIPLE,
+                           code_scheme=CodeSchemes.DADAAB_S01E03,
+                           coded_field="rqa_s01e03_coded",
+                           analysis_file_key="rqa_s01e03_",
+                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.DADAAB_S01E03, x, y)
+                       )
+                   ],
+                   ws_code=CodeSchemes.DADAAB_WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("covid19 adaptation dadaab s01e03"),
+                   raw_field_fold_strategy=FoldStrategies.concatenate),
+
+        CodingPlan(raw_field="rqa_s01e04_raw",
+                   dataset_name="dadaab_s01e04",
+                   time_field="sent_on",
+                   run_id_field="rqa_s01e04_run_id",
+                   coda_filename="dadaab_s01e04.json",
+                   icr_filename="dadaab_s01e04.csv",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.MULTIPLE,
+                           code_scheme=CodeSchemes.DADAAB_S01E04,
+                           coded_field="rqa_s01e04_coded",
+                           analysis_file_key="rqa_s01e04_",
+                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.DADAAB_S01E04, x, y)
+                       )
+                   ],
+                   ws_code=CodeSchemes.DADAAB_WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("covid19 adaptation dadaab s01e04"),
+                   raw_field_fold_strategy=FoldStrategies.concatenate),
+
+        CodingPlan(raw_field="rqa_s01e05_raw",
+                   dataset_name="dadaab_s01e05",
+                   time_field="sent_on",
+                   run_id_field="rqa_s01e05_run_id",
+                   coda_filename="dadaab_s01e05.json",
+                   icr_filename="dadaab_s01e05.csv",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.MULTIPLE,
+                           code_scheme=CodeSchemes.DADAAB_S01E05,
+                           coded_field="rqa_s01e05_coded",
+                           analysis_file_key="rqa_s01e05_",
+                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.DADAAB_S01E05, x, y)
+                       )
+                   ],
+                   ws_code=CodeSchemes.DADAAB_WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("covid19 adaptation dadaab s01e05"),
+                   raw_field_fold_strategy=FoldStrategies.concatenate),
+
+        CodingPlan(raw_field="rqa_s01e06_raw",
+                   dataset_name="dadaab_s01e06",
+                   time_field="sent_on",
+                   run_id_field="rqa_s01e06_run_id",
+                   coda_filename="dadaab_s01e06.json",
+                   icr_filename="dadaab_s01e06.csv",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.MULTIPLE,
+                           code_scheme=CodeSchemes.DADAAB_S01E06,
+                           coded_field="rqa_s01e06_coded",
+                           analysis_file_key="rqa_s01e06_",
+                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.DADAAB_S01E06, x, y)
+                       )
+                   ],
+                   ws_code=CodeSchemes.DADAAB_WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("covid19 adaptation dadaab s01e06"),
+                   raw_field_fold_strategy=FoldStrategies.concatenate),
+
+        CodingPlan(raw_field="rqa_s01e07_raw",
+                   dataset_name="dadaab_s01e07",
+                   time_field="sent_on",
+                   run_id_field="rqa_s01e07_run_id",
+                   coda_filename="dadaab_s01e07.json",
+                   icr_filename="dadaab_s01e07.csv",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.MULTIPLE,
+                           code_scheme=CodeSchemes.DADAAB_S01E07,
+                           coded_field="rqa_s01e07_coded",
+                           analysis_file_key="rqa_s01e07_",
+                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.DADAAB_S01E07, x, y)
+                       )
+                   ],
+                   ws_code=CodeSchemes.DADAAB_WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("covid19 adaptation dadaab s01e07"),
+                   raw_field_fold_strategy=FoldStrategies.concatenate),
+
+        CodingPlan(raw_field="rqa_s01e08_raw",
+                   dataset_name="dadaab_s01e08",
+                   time_field="sent_on",
+                   run_id_field="rqa_s01e08_run_id",
+                   coda_filename="dadaab_s01e08.json",
+                   icr_filename="dadaab_s01e08.csv",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.MULTIPLE,
+                           code_scheme=CodeSchemes.DADAAB_S01E08,
+                           coded_field="rqa_s01e08_coded",
+                           analysis_file_key="rqa_s01e08_",
+                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.DADAAB_S01E08, x, y)
+                       )
+                   ],
+                   ws_code=CodeSchemes.DADAAB_WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("covid19 adaptation dadaab s01e08"),
+                   raw_field_fold_strategy=FoldStrategies.concatenate),
+
+        CodingPlan(raw_field="rqa_s01e09_raw",
+                   dataset_name="dadaab_s01e09",
+                   time_field="sent_on",
+                   run_id_field="rqa_s01e09_run_id",
+                   coda_filename="dadaab_s01e09.json",
+                   icr_filename="dadaab_s01e09.csv",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.MULTIPLE,
+                           code_scheme=CodeSchemes.DADAAB_S01E09,
+                           coded_field="rqa_s01e09_coded",
+                           analysis_file_key="rqa_s01e09_",
+                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.DADAAB_S01E09, x, y)
+                       )
+                   ],
+                   ws_code=CodeSchemes.DADAAB_WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("covid19 adaptation dadaab s01e09"),
+                   raw_field_fold_strategy=FoldStrategies.concatenate),
+
+        CodingPlan(raw_field="rqa_s01e10_raw",
+                   dataset_name="dadaab_s01e10",
+                   time_field="sent_on",
+                   run_id_field="rqa_s01e10_run_id",
+                   coda_filename="dadaab_s01e10.json",
+                   icr_filename="dadaab_s01e09.csv",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.MULTIPLE,
+                           code_scheme=CodeSchemes.DADAAB_S01E10,
+                           coded_field="rqa_s01e10_coded",
+                           analysis_file_key="rqa_s01e10_",
+                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.DADAAB_S01E10, x, y)
+                       )
+                   ],
+                   ws_code=CodeSchemes.DADAAB_WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("covid19 adaptation dadaab s01e10"),
+                   raw_field_fold_strategy=FoldStrategies.concatenate),
+    ]
+
+    KAKUMA_RQA_CODING_PLANS = [
+        CodingPlan(raw_field="rqa_s01e01_raw",
+                   dataset_name="kakuma_s01e01",
+                   time_field="sent_on",
+                   run_id_field="rqa_s01e01_run_id",
+                   coda_filename="kakuma_s01e01.json",
+                   icr_filename="kakuma_s01e01.csv",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.MULTIPLE,
+                           code_scheme=CodeSchemes.KAKUMA_S01E01,
+                           coded_field="rqa_s01e01_coded",
+                           analysis_file_key="rqa_s01e01_",
+                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.KAKUMA_S01E01, x, y)
+                       )
+                   ],
+                   ws_code=CodeSchemes.KAKUMA_WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("covid19 adaptation kakuma s01e01"),
+                   raw_field_fold_strategy=FoldStrategies.concatenate),
+
+        CodingPlan(raw_field="rqa_s01e02_raw",
+                   dataset_name="kakuma_s01e02",
+                   time_field="sent_on",
+                   run_id_field="rqa_s01e02_run_id",
+                   coda_filename="kakuma_s01e02.json",
+                   icr_filename="kakuma_s01e02.csv",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.MULTIPLE,
+                           code_scheme=CodeSchemes.KAKUMA_S01E02,
+                           coded_field="rqa_s01e02_coded",
+                           analysis_file_key="rqa_s01e02_",
+                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.KAKUMA_S01E02, x, y)
+                       )
+                   ],
+                   ws_code=CodeSchemes.KAKUMA_WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("covid19 adaptation kakuma s01e02"),
+                   raw_field_fold_strategy=FoldStrategies.concatenate),
+
+        CodingPlan(raw_field="rqa_s01e03_raw",
+                   dataset_name="kakuma_s01e03",
+                   time_field="sent_on",
+                   run_id_field="rqa_s01e03_run_id",
+                   coda_filename="kakuma_s01e03.json",
+                   icr_filename="kakuma_s01e03.csv",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.MULTIPLE,
+                           code_scheme=CodeSchemes.KAKUMA_S01E03,
+                           coded_field="rqa_s01e03_coded",
+                           analysis_file_key="rqa_s01e03_",
+                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.KAKUMA_S01E03, x, y)
+                       )
+                   ],
+                   ws_code=CodeSchemes.KAKUMA_WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("covid19 adaptation kakuma s01e03"),
+                   raw_field_fold_strategy=FoldStrategies.concatenate),
+
+        CodingPlan(raw_field="rqa_s01e04_raw",
+                   dataset_name="kakuma_s01e04",
+                   time_field="sent_on",
+                   run_id_field="rqa_s01e04_run_id",
+                   coda_filename="kakuma_s01e04.json",
+                   icr_filename="kakuma_s01e04.csv",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.MULTIPLE,
+                           code_scheme=CodeSchemes.KAKUMA_S01E04,
+                           coded_field="rqa_s01e04_coded",
+                           analysis_file_key="rqa_s01e04_",
+                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.KAKUMA_S01E04, x, y)
+                       )
+                   ],
+                   ws_code=CodeSchemes.KAKUMA_WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("covid19 adaptation kakuma s01e04"),
+                   raw_field_fold_strategy=FoldStrategies.concatenate),
+
+        CodingPlan(raw_field="rqa_s01e05_raw",
+                   dataset_name="kakuma_s01e05",
+                   time_field="sent_on",
+                   run_id_field="rqa_s01e05_run_id",
+                   coda_filename="kakuma_s01e05.json",
+                   icr_filename="kakuma_s01e05.csv",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.MULTIPLE,
+                           code_scheme=CodeSchemes.KAKUMA_S01E05,
+                           coded_field="rqa_s01e05_coded",
+                           analysis_file_key="rqa_s01e05_",
+                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.KAKUMA_S01E05, x, y)
+                       )
+                   ],
+                   ws_code=CodeSchemes.KAKUMA_WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("covid19 adaptation kakuma s01e05"),
+                   raw_field_fold_strategy=FoldStrategies.concatenate),
+
+        CodingPlan(raw_field="rqa_s01e06_raw",
+                   dataset_name="kakuma_s01e06",
+                   time_field="sent_on",
+                   run_id_field="rqa_s01e06_run_id",
+                   coda_filename="kakuma_s01e06.json",
+                   icr_filename="kakuma_s01e06.csv",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.MULTIPLE,
+                           code_scheme=CodeSchemes.KAKUMA_S01E06,
+                           coded_field="rqa_s01e06_coded",
+                           analysis_file_key="rqa_s01e06_",
+                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.KAKUMA_S01E06, x, y)
+                       )
+                   ],
+                   ws_code=CodeSchemes.KAKUMA_WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("covid19 adaptation kakuma s01e06"),
+                   raw_field_fold_strategy=FoldStrategies.concatenate),
+
+        CodingPlan(raw_field="rqa_s01e07_raw",
+                   dataset_name="kakuma_s01e07",
+                   time_field="sent_on",
+                   run_id_field="rqa_s01e07_run_id",
+                   coda_filename="kakuma_s01e07.json",
+                   icr_filename="kakuma_s01e07.csv",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.MULTIPLE,
+                           code_scheme=CodeSchemes.KAKUMA_S01E07,
+                           coded_field="rqa_s01e07_coded",
+                           analysis_file_key="rqa_s01e07_",
+                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.KAKUMA_S01E07, x, y)
+                       )
+                   ],
+                   ws_code=CodeSchemes.KAKUMA_WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("covid19 adaptation kakuma s01e07"),
+                   raw_field_fold_strategy=FoldStrategies.concatenate),
+
+        CodingPlan(raw_field="rqa_s01e08_raw",
+                   dataset_name="kakuma_s01e08",
+                   time_field="sent_on",
+                   run_id_field="rqa_s01e08_run_id",
+                   coda_filename="kakuma_s01e08.json",
+                   icr_filename="kakuma_s01e08.csv",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.MULTIPLE,
+                           code_scheme=CodeSchemes.KAKUMA_S01E08,
+                           coded_field="rqa_s01e08_coded",
+                           analysis_file_key="rqa_s01e08_",
+                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.KAKUMA_S01E08, x, y)
+                       )
+                   ],
+                   ws_code=CodeSchemes.KAKUMA_WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("covid19 adaptation kakuma s01e08"),
+                   raw_field_fold_strategy=FoldStrategies.concatenate),
+
+        CodingPlan(raw_field="rqa_s01e09_raw",
+                   dataset_name="kakuma_s01e09",
+                   time_field="sent_on",
+                   run_id_field="rqa_s01e09_run_id",
+                   coda_filename="kakuma_s01e09.json",
+                   icr_filename="kakuma_s01e09.csv",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.MULTIPLE,
+                           code_scheme=CodeSchemes.KAKUMA_S01E09,
+                           coded_field="rqa_s01e09_coded",
+                           analysis_file_key="rqa_s01e09_",
+                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.KAKUMA_S01E09, x, y)
+                       )
+                   ],
+                   ws_code=CodeSchemes.KAKUMA_WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("covid19 adaptation kakuma s01e09"),
+                   raw_field_fold_strategy=FoldStrategies.concatenate),
+
+        CodingPlan(raw_field="rqa_s01e10_raw",
+                   dataset_name="kakuma_s01e10",
+                   time_field="sent_on",
+                   run_id_field="rqa_s01e10_run_id",
+                   coda_filename="kakuma_s01e10.json",
+                   icr_filename="kakuma_s01e10.csv",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.MULTIPLE,
+                           code_scheme=CodeSchemes.KAKUMA_S01E10,
+                           coded_field="rqa_s01e10_coded",
+                           analysis_file_key="rqa_s01e10_",
+                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.KAKUMA_S01E10, x, y)
+                       )
+                   ],
+                   ws_code=CodeSchemes.KAKUMA_WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("covid19 adaptation kakuma s01e10"),
+                   raw_field_fold_strategy=FoldStrategies.concatenate),
+    ]
+
+    @staticmethod
+    def clean_age_with_range_filter(text):
+        """
+        Cleans age from the given `text`, setting to NC if the cleaned age is not in the range 10 <= age < 100.
+        """
+        age = swahili.DemographicCleaner.clean_age(text)
+        if type(age) == int and 10 <= age < 100:
+            return str(age)
+            # TODO: Once the cleaners are updated to not return Codes.NOT_CODED, this should be updated to still return
+            #       NC in the case where age is an int but is out of range
+        else:
+            return Codes.NOT_CODED
+
+    SURVEY_CODING_PLANS = None
+
+    KAKUMA_DEMOG_CODING_PLANS = [
+
+        CodingPlan(raw_field="location_raw",
+                   dataset_name="kakuma_location",
+                   time_field="location_time",
+                   coda_filename="kakuma_location.json",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.SINGLE,
+                           code_scheme=CodeSchemes.KAKUMA_LOCATION,
+                           coded_field="location_coded",
+                           analysis_file_key="location",
+                           fold_strategy=FoldStrategies.assert_label_ids_equal
+                       ),
+                   ],
+                   ws_code=CodeSchemes.KAKUMA_WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("kakuma location"),
+                   raw_field_fold_strategy=FoldStrategies.assert_equal),
+
+        CodingPlan(raw_field="gender_raw",
+                   dataset_name="kakuma_gender",
+                   time_field="gender_time",
+                   coda_filename="kakuma_gender.json",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.SINGLE,
+                           code_scheme=CodeSchemes.GENDER,
+                           cleaner=somali.DemographicCleaner.clean_gender,
+                           coded_field="gender_coded",
+                           analysis_file_key="gender",
+                           fold_strategy=FoldStrategies.assert_label_ids_equal
+                       )
+                   ],
+                   ws_code=CodeSchemes.KAKUMA_WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("kakuma gender"),
+                   raw_field_fold_strategy=FoldStrategies.assert_equal),
+
+        CodingPlan(raw_field="age_raw",
+                   dataset_name="kakuma_age",
+                   time_field="age_time",
+                   coda_filename="kakuma_age.json",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.SINGLE,
+                           code_scheme=CodeSchemes.AGE,
+                           cleaner=lambda text: PipelineConfiguration.clean_age_with_range_filter(text),
+                           coded_field="age_coded",
+                           analysis_file_key="age",
+                           fold_strategy=FoldStrategies.assert_label_ids_equal
+                       ),
+                       CodingConfiguration(
+                           coding_mode=CodingModes.SINGLE,
+                           code_scheme=CodeSchemes.AGE_CATEGORY,
+                           coded_field="age_category_coded",
+                           analysis_file_key="age_category",
+                           fold_strategy=FoldStrategies.assert_label_ids_equal
+                       )
+                   ],
+                   code_imputation_function=code_imputation_functions.impute_age_category,
+                   ws_code=CodeSchemes.KAKUMA_WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("kakuma age"),
+                   raw_field_fold_strategy=FoldStrategies.assert_equal),
+
+        CodingPlan(raw_field="household_language_raw",
+                   dataset_name="kakuma_household_language",
+                   time_field="household_language_time",
+                   coda_filename="kakuma_household_language.json",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.SINGLE,
+                           code_scheme=CodeSchemes.KAKUMA_HOUSEHOLD_LANGUAGE,
+                           coded_field="household_language_coded",
+                           analysis_file_key="household_language",
+                           fold_strategy=FoldStrategies.assert_label_ids_equal
+                       )
+                   ],
+                   ws_code=CodeSchemes.KAKUMA_WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("kakuma household language"),
+                   raw_field_fold_strategy=FoldStrategies.assert_equal),
+
+        CodingPlan(raw_field="nationality_raw",
+                   dataset_name="kakuma_nationality",
+                   time_field="nationality_time",
+                   coda_filename="kakuma_nationality.json",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.SINGLE,
+                           code_scheme=CodeSchemes.NATIONALITY,
+                           coded_field="nationality_coded",
+                           analysis_file_key="nationality",
+                           fold_strategy=FoldStrategies.assert_label_ids_equal
+                       )
+                   ],
+                   ws_code=CodeSchemes.KAKUMA_WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("kakuma nationality"),
+                   raw_field_fold_strategy=FoldStrategies.assert_equal),
+    ]
+
+    KAKUMA_FOLLOW_UP_SURVEY_CODING_PLANS = []
+
+    KAKUMA_SURVEY_CODING_PLANS = KAKUMA_DEMOG_CODING_PLANS + KAKUMA_FOLLOW_UP_SURVEY_CODING_PLANS
+
+    DADAAB_DEMOG_CODING_PLANS = [
+
+        CodingPlan(raw_field="location_raw",
+                   dataset_name="dadaab_location",
+                   time_field="location_time",
+                   coda_filename="dadaab_location.json",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.SINGLE,
+                           code_scheme=CodeSchemes.DADAAB_LOCATION,
+                           coded_field="location_coded",
+                           analysis_file_key="location",
+                           fold_strategy=FoldStrategies.assert_label_ids_equal
+                       ),
+                   ],
+                   ws_code=CodeSchemes.DADAAB_WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("dadaab location"),
+                   raw_field_fold_strategy=FoldStrategies.assert_equal),
+
+        CodingPlan(raw_field="gender_raw",
+                   dataset_name="dadaab_gender",
+                   time_field="gender_time",
+                   coda_filename="dadaab_gender.json",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.SINGLE,
+                           code_scheme=CodeSchemes.GENDER,
+                           cleaner=somali.DemographicCleaner.clean_gender,
+                           coded_field="gender_coded",
+                           analysis_file_key="gender",
+                           fold_strategy=FoldStrategies.assert_label_ids_equal
+                       )
+                   ],
+                   ws_code=CodeSchemes.DADAAB_WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("dadaab gender"),
+                   raw_field_fold_strategy=FoldStrategies.assert_equal),
+
+        CodingPlan(raw_field="age_raw",
+                   dataset_name="dadaab_age",
+                   time_field="age_time",
+                   coda_filename="dadaab_age.json",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.SINGLE,
+                           code_scheme=CodeSchemes.AGE,
+                           cleaner=lambda text: PipelineConfiguration.clean_age_with_range_filter(text),
+                           coded_field="age_coded",
+                           analysis_file_key="age",
+                           fold_strategy=FoldStrategies.assert_label_ids_equal
+                       ),
+                       CodingConfiguration(
+                           coding_mode=CodingModes.SINGLE,
+                           code_scheme=CodeSchemes.AGE_CATEGORY,
+                           coded_field="age_category_coded",
+                           analysis_file_key="age_category",
+                           fold_strategy=FoldStrategies.assert_label_ids_equal
+                       )
+                   ],
+                   code_imputation_function=code_imputation_functions.impute_age_category,
+                   ws_code=CodeSchemes.DADAAB_WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("dadaab age"),
+                   raw_field_fold_strategy=FoldStrategies.assert_equal),
+
+        CodingPlan(raw_field="household_language_raw",
+                   dataset_name="dadaab_household_language",
+                   time_field="household_language_time",
+                   coda_filename="dadaab_household_language.json",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.SINGLE,
+                           code_scheme=CodeSchemes.DADAAB_HOUSEHOLD_LANGUAGE,
+                           coded_field="household_language_coded",
+                           analysis_file_key="household_language",
+                           fold_strategy=FoldStrategies.assert_label_ids_equal
+                       )
+                   ],
+                   ws_code=CodeSchemes.DADAAB_WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("dadaab household language"),
+                   raw_field_fold_strategy=FoldStrategies.assert_equal),
+
+        CodingPlan(raw_field="nationality_raw",
+                   dataset_name="dadaab_nationality",
+                   time_field="nationality_time",
+                   coda_filename="dadaab_nationality.json",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.SINGLE,
+                           code_scheme=CodeSchemes.NATIONALITY,
+                           coded_field="nationality_coded",
+                           analysis_file_key="nationality",
+                           fold_strategy=FoldStrategies.assert_label_ids_equal
+                       )
+                   ],
+                   ws_code=CodeSchemes.DADAAB_WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("dadaab nationality"),
+                   raw_field_fold_strategy=FoldStrategies.assert_equal),
+    ]
+
+    DADAAB_FOLLOW_UP_SURVEY_CODING_PLANS = [ ]
+
+    DADAAB_SURVEY_CODING_PLANS = DADAAB_DEMOG_CODING_PLANS + DADAAB_FOLLOW_UP_SURVEY_CODING_PLANS
+
+    def __init__(self, raw_data_sources, phone_number_uuid_table, timestamp_remappings,
+                 rapid_pro_key_remappings, project_start_date, project_end_date, filter_test_messages, move_ws_messages,
+                 memory_profile_upload_url_prefix, data_archive_upload_url_prefix, pipeline_name=None,
+                 drive_upload=None, listening_group_csv_urls=None):
+        """
+        :param raw_data_sources: List of sources to pull the various raw run files from.
+        :type raw_data_sources: list of RawDataSource
+        :param phone_number_uuid_table: Configuration for the Firestore phone number <-> uuid table.
+        :type phone_number_uuid_table: PhoneNumberUuidTable
+        :param rapid_pro_key_remappings: List of rapid_pro_key -> pipeline_key remappings.
+        :type rapid_pro_key_remappings: list of RapidProKeyRemapping
+        :param project_start_date: When data collection started - all activation messages received before this date
+                                   time will be dropped.
+        :type project_start_date: datetime.datetime
+        :param project_end_date: When data collection stopped - all activation messages received on or after this date
+                                 time will be dropped.
+        :type project_end_date: datetime.datetime
+        :param filter_test_messages: Whether to filter out messages sent from the rapid_pro_test_contact_uuids
+        :type filter_test_messages: bool
+        :param move_ws_messages: Whether to move messages labelled as Wrong Scheme to the correct dataset.
+        :type move_ws_messages: bool
+        :param memory_profile_upload_url_prefix: The prefix of the GS URL to upload the memory profile log to.
+                                                 This prefix will be appended by the id of the pipeline run (provided
+                                                 as a command line argument), and the ".profile" file extension.
+        :type memory_profile_upload_url_prefix: str
+        :param pipeline_name: The name of the pipeline to run.
+        :type pipeline_name: str | None
+        :param drive_upload: Configuration for uploading to Google Drive, or None.
+                             If None, does not upload to Google Drive.
+        :type drive_upload: DriveUploadPaths | None
+        :param listening_group_csv_urls: Google cloud storage urls to fetch listening group csvs from.
+        :type listening_group_csv_urls: list of str | None
+        """
+        self.raw_data_sources = raw_data_sources
+        self.phone_number_uuid_table = phone_number_uuid_table
+        self.timestamp_remappings = timestamp_remappings
+        self.rapid_pro_key_remappings = rapid_pro_key_remappings
+        self.project_start_date = project_start_date
+        self.project_end_date = project_end_date
+        self.filter_test_messages = filter_test_messages
+        self.move_ws_messages = move_ws_messages
+        self.memory_profile_upload_url_prefix = memory_profile_upload_url_prefix
+        self.data_archive_upload_url_prefix = data_archive_upload_url_prefix
+        self.pipeline_name = pipeline_name
+        self.drive_upload = drive_upload
+        self.listening_group_csv_urls = listening_group_csv_urls
+        self.validate()
+
+    @classmethod
+    def from_configuration_dict(cls, configuration_dict):
+        raw_data_sources = []
+        for raw_data_source in configuration_dict["RawDataSources"]:
+            if raw_data_source["SourceType"] == "RapidPro":
+                raw_data_sources.append(RapidProSource.from_configuration_dict(raw_data_source))
+            else:
+                assert False, f"Unknown SourceType '{raw_data_source['SourceType']}'. " \
+                    f"Must be 'RapidPro'"
+
+        phone_number_uuid_table = PhoneNumberUuidTable.from_configuration_dict(
+            configuration_dict["PhoneNumberUuidTable"])
+
+        timestamp_remappings = []
+        for remapping_dict in configuration_dict.get("TimestampRemappings", []):
+            timestamp_remappings.append(TimestampRemapping.from_configuration_dict(remapping_dict))
+
+        rapid_pro_key_remappings = []
+        for remapping_dict in configuration_dict["RapidProKeyRemappings"]:
+            rapid_pro_key_remappings.append(RapidProKeyRemapping.from_configuration_dict(remapping_dict))
+
+        project_start_date = isoparse(configuration_dict["ProjectStartDate"])
+        project_end_date = isoparse(configuration_dict["ProjectEndDate"])
+
+        filter_test_messages = configuration_dict["FilterTestMessages"]
+        move_ws_messages = configuration_dict["MoveWSMessages"]
+
+        memory_profile_upload_url_prefix = configuration_dict["MemoryProfileUploadURLPrefix"]
+        data_archive_upload_url_prefix = configuration_dict["DataArchiveUploadURLPrefix"]
+
+        pipeline_name = configuration_dict.get("PipelineName")
+
+        drive_upload_paths = None
+        if "DriveUpload" in configuration_dict:
+            drive_upload_paths = DriveUpload.from_configuration_dict(configuration_dict["DriveUpload"])
+
+        listening_group_csv_urls = configuration_dict.get("ListeningGroupCSVURLs")
+
+        return cls(raw_data_sources, phone_number_uuid_table, timestamp_remappings,
+                   rapid_pro_key_remappings, project_start_date, project_end_date, filter_test_messages,
+                   move_ws_messages, memory_profile_upload_url_prefix, data_archive_upload_url_prefix, pipeline_name,
+                   drive_upload_paths, listening_group_csv_urls)
+
+    @classmethod
+    def from_configuration_file(cls, f):
+        return cls.from_configuration_dict(json.load(f))
+
+    def validate(self):
+        validators.validate_list(self.raw_data_sources, "raw_data_sources")
+        for i, raw_data_source in enumerate(self.raw_data_sources):
+            assert isinstance(raw_data_source, RawDataSource), f"raw_data_sources[{i}] is not of type of RawDataSource"
+            raw_data_source.validate()
+
+        assert isinstance(self.phone_number_uuid_table, PhoneNumberUuidTable)
+        self.phone_number_uuid_table.validate()
+
+        validators.validate_list(self.rapid_pro_key_remappings, "rapid_pro_key_remappings")
+        for i, remapping in enumerate(self.rapid_pro_key_remappings):
+            assert isinstance(remapping, RapidProKeyRemapping), \
+                f"rapid_pro_key_mappings[{i}] is not of type RapidProKeyRemapping"
+            remapping.validate()
+
+        validators.validate_datetime(self.project_start_date, "project_start_date")
+        validators.validate_datetime(self.project_end_date, "project_end_date")
+
+        validators.validate_bool(self.filter_test_messages, "filter_test_messages")
+        validators.validate_bool(self.move_ws_messages, "move_ws_messages")
+
+        if self.pipeline_name is not None:
+            validators.validate_string(self.pipeline_name, "pipeline_name")
+
+        if self.drive_upload is not None:
+            assert isinstance(self.drive_upload, DriveUpload), \
+                "drive_upload is not of type DriveUpload"
+            self.drive_upload.validate()
+
+        validators.validate_string(self.memory_profile_upload_url_prefix, "memory_profile_upload_url_prefix")
+
+        if self.listening_group_csv_urls is not None:
+            validators.validate_list(self.listening_group_csv_urls, "listening_group_csv_urls")
+            for i, listening_group_csv_url in enumerate(self.listening_group_csv_urls):
+                validators.validate_string(listening_group_csv_url, f"{listening_group_csv_url}")
+
+
+class RawDataSource(ABC):
+    @abstractmethod
+    def get_activation_flow_names(self):
+        pass
+
+    @abstractmethod
+    def get_survey_flow_names(self):
+        pass
+
+    @abstractmethod
+    def validate(self):
+        pass
+
+
+class RapidProSource(RawDataSource):
+    def __init__(self, domain, token_file_url, contacts_file_name, activation_flow_names, survey_flow_names,
+                 test_contact_uuids):
+        """
+        :param domain: URL of the Rapid Pro server to download data from.
+        :type domain: str
+        :param token_file_url: GS URL of a text file containing the authorisation token for the Rapid Pro server.
+        :type token_file_url: str
+        :param contacts_file_name:
+        :type contacts_file_name: str
+        :param activation_flow_names: The names of the RapidPro flows that contain the radio show responses.
+        :type: activation_flow_names: list of str
+        :param survey_flow_names: The names of the RapidPro flows that contain the survey responses.
+        :type: survey_flow_names: list of str
+        :param test_contact_uuids: Rapid Pro contact UUIDs of test contacts.
+                                   Runs for any of those test contacts will be tagged with {'test_run': True},
+                                   and dropped when the pipeline is run with "FilterTestMessages" set to true.
+        :type test_contact_uuids: list of str
+        """
+        self.domain = domain
+        self.token_file_url = token_file_url
+        self.contacts_file_name = contacts_file_name
+        self.activation_flow_names = activation_flow_names
+        self.survey_flow_names = survey_flow_names
+        self.test_contact_uuids = test_contact_uuids
+
+        self.validate()
+
+    def get_activation_flow_names(self):
+        return self.activation_flow_names
+
+    def get_survey_flow_names(self):
+        return self.survey_flow_names
+
+    @classmethod
+    def from_configuration_dict(cls, configuration_dict):
+        domain = configuration_dict["Domain"]
+        token_file_url = configuration_dict["TokenFileURL"]
+        contacts_file_name = configuration_dict["ContactsFileName"]
+        activation_flow_names = configuration_dict.get("ActivationFlowNames", [])
+        survey_flow_names = configuration_dict.get("SurveyFlowNames", [])
+        test_contact_uuids = configuration_dict.get("TestContactUUIDs", [])
+
+        return cls(domain, token_file_url, contacts_file_name, activation_flow_names,
+                   survey_flow_names, test_contact_uuids)
+
+    def validate(self):
+        validators.validate_string(self.domain, "domain")
+        validators.validate_string(self.token_file_url, "token_file_url")
+        validators.validate_string(self.contacts_file_name, "contacts_file_name")
+
+        validators.validate_list(self.activation_flow_names, "activation_flow_names")
+        for i, activation_flow_name in enumerate(self.activation_flow_names):
+            validators.validate_string(activation_flow_name, f"activation_flow_names[{i}]")
+
+        validators.validate_list(self.survey_flow_names, "survey_flow_names")
+        for i, survey_flow_name in enumerate(self.survey_flow_names):
+            validators.validate_string(survey_flow_name, f"survey_flow_names[{i}]")
+
+        validators.validate_list(self.test_contact_uuids, "test_contact_uuids")
+        for i, contact_uuid in enumerate(self.test_contact_uuids):
+            validators.validate_string(contact_uuid, f"test_contact_uuids[{i}]")
+
+
+class AbstractRemoteURLSource(RawDataSource):
+    def __init__(self, activation_flow_urls, survey_flow_urls):
+        self.activation_flow_urls = activation_flow_urls
+        self.survey_flow_urls = survey_flow_urls
+
+        self.validate()
+
+    def get_activation_flow_names(self):
+        return [url.split('/')[-1].split('.')[0] for url in self.activation_flow_urls]
+
+    def get_survey_flow_names(self):
+        return [url.split('/')[-1].split('.')[0] for url in self.survey_flow_urls]
+
+    @classmethod
+    def from_configuration_dict(cls, configuration_dict):
+        activation_flow_urls = configuration_dict.get("ActivationFlowURLs", [])
+        survey_flow_urls = configuration_dict.get("SurveyFlowURLs", [])
+
+        return cls(activation_flow_urls, survey_flow_urls)
+
+    def validate(self):
+        validators.validate_list(self.activation_flow_urls, "activation_flow_urls")
+        for i, activation_flow_url in enumerate(self.activation_flow_urls):
+            validators.validate_url(activation_flow_url, f"activation_flow_urls[{i}]", "gs")
+
+        validators.validate_list(self.survey_flow_urls, "survey_flow_urls")
+        for i, survey_flow_url in enumerate(self.survey_flow_urls):
+            validators.validate_url(survey_flow_url, f"survey_flow_urls[{i}]", "gs")
+
+
+class PhoneNumberUuidTable(object):
+    def __init__(self, firebase_credentials_file_url, table_name):
+        """
+        :param firebase_credentials_file_url: GS URL to the private credentials file for the Firebase account where
+                                                 the phone number <-> uuid table is stored.
+        :type firebase_credentials_file_url: str
+        :param table_name: Name of the data <-> uuid table in Firebase to use.
+        :type table_name: str
+        """
+        self.firebase_credentials_file_url = firebase_credentials_file_url
+        self.table_name = table_name
+
+        self.validate()
+
+    @classmethod
+    def from_configuration_dict(cls, configuration_dict):
+        firebase_credentials_file_url = configuration_dict["FirebaseCredentialsFileURL"]
+        table_name = configuration_dict["TableName"]
+
+        return cls(firebase_credentials_file_url, table_name)
+
+    def validate(self):
+        validators.validate_url(self.firebase_credentials_file_url, "firebase_credentials_file_url", scheme="gs")
+        validators.validate_string(self.table_name, "table_name")
+
+
+class TimestampRemapping(object):
+    def __init__(self, time_key, show_pipeline_key_to_remap_to, range_start_inclusive=None, range_end_exclusive=None,
+                 time_to_adjust_to=None):
+        """
+        Specifies a remapping of messages received within the given time range to another radio show field.
+        Optionally specifies an adjustment of all affected timestamps to a constant datetime.
+
+        :param time_key: Key in each TracedData of an ISO 8601-formatted datetime string to read the message sent on
+                         time from.
+        :type time_key: str
+        :param show_pipeline_key_to_remap_to: Pipeline key to assign to messages received within the given time range.
+        :type show_pipeline_key_to_remap_to: str
+        :param range_start_inclusive: Start datetime for the time range to remap radio show messages from, inclusive.
+                                      If None, defaults to the beginning of time.
+        :type range_start_inclusive: datetime | None
+        :param range_end_exclusive: End datetime for the time range to remap radio show messages from, exclusive.
+                                    If None, defaults to the end of time.
+        :type range_end_exclusive: datetime | None
+        :param time_to_adjust_to: Datetime to adjust each message object's `time_key` field to, or None.
+                                  If None, re-mapped shows will not have timestamps adjusted.
+        :type time_to_adjust_to: datetime | None
+        """
+        if range_start_inclusive is None:
+            range_start_inclusive = pytz.utc.localize(datetime.min)
+        if range_end_exclusive is None:
+            range_end_exclusive = pytz.utc.localize(datetime.max)
+
+        self.time_key = time_key
+        self.show_pipeline_key_to_remap_to = show_pipeline_key_to_remap_to
+        self.range_start_inclusive = range_start_inclusive
+        self.range_end_exclusive = range_end_exclusive
+        self.time_to_adjust_to = time_to_adjust_to
+
+        self.validate()
+
+    @classmethod
+    def from_configuration_dict(cls, configuration_dict):
+        time_key = configuration_dict["TimeKey"]
+        show_pipeline_key_to_remap_to = configuration_dict["ShowPipelineKeyToRemapTo"]
+        range_start_inclusive = configuration_dict.get("RangeStartInclusive")
+        range_end_exclusive = configuration_dict.get("RangeEndExclusive")
+        time_to_adjust_to = configuration_dict.get("TimeToAdjustTo")
+
+        if range_start_inclusive is not None:
+            range_start_inclusive = isoparse(range_start_inclusive)
+        if range_end_exclusive is not None:
+            range_end_exclusive = isoparse(range_end_exclusive)
+        if time_to_adjust_to is not None:
+            time_to_adjust_to = isoparse(time_to_adjust_to)
+
+        return cls(time_key, show_pipeline_key_to_remap_to, range_start_inclusive, range_end_exclusive,
+                   time_to_adjust_to)
+
+    def validate(self):
+        validators.validate_string(self.time_key, "time_key")
+        validators.validate_string(self.show_pipeline_key_to_remap_to, "show_pipeline_key_to_remap_to")
+        validators.validate_datetime(self.range_start_inclusive, "range_start_inclusive")
+        validators.validate_datetime(self.range_end_exclusive, "range_end_exclusive")
+
+        if self.time_to_adjust_to is not None:
+            validators.validate_datetime(self.time_to_adjust_to, "time_to_adjust_to")
+
+
+class RapidProKeyRemapping(object):
+    def __init__(self, is_activation_message, rapid_pro_key, pipeline_key):
+        """
+        :param is_activation_message: Whether this re-mapping contains an activation message (activation messages need
+                                   to be handled differently because they are not always in the correct flow)
+        :type is_activation_message: bool
+        :param rapid_pro_key: Name of key in the dataset exported via RapidProTools.
+        :type rapid_pro_key: str
+        :param pipeline_key: Name to use for that key in the rest of the pipeline.
+        :type pipeline_key: str
+        """
+        self.is_activation_message = is_activation_message
+        self.rapid_pro_key = rapid_pro_key
+        self.pipeline_key = pipeline_key
+
+        self.validate()
+
+    @classmethod
+    def from_configuration_dict(cls, configuration_dict):
+        is_activation_message = configuration_dict.get("IsActivationMessage", False)
+        rapid_pro_key = configuration_dict["RapidProKey"]
+        pipeline_key = configuration_dict["PipelineKey"]
+
+        return cls(is_activation_message, rapid_pro_key, pipeline_key)
+
+    def validate(self):
+        validators.validate_bool(self.is_activation_message, "is_activation_message")
+        validators.validate_string(self.rapid_pro_key, "rapid_pro_key")
+        validators.validate_string(self.pipeline_key, "pipeline_key")
+
+
+class DriveUpload(object):
+    def __init__(self, drive_credentials_file_url, production_upload_path, messages_upload_path,
+                 individuals_upload_path, automated_analysis_dir):
+        """
+        :param drive_credentials_file_url: GS URL to the private credentials file for the Drive service account to use
+                                           to upload the output files.
+        :type drive_credentials_file_url: str
+        :param production_upload_path: Path in the Drive service account's "Shared with Me" directory to upload the
+                                       production CSV to.
+        :type production_upload_path: str
+        :param messages_upload_path: Path in the Drive service account's "Shared with Me" directory to upload the
+                                     messages analysis CSV to.
+        :type messages_upload_path: str
+        :param individuals_upload_path: Path in the Drive service account's "Shared with Me" directory to upload the
+                                        individuals analysis CSV to.
+        :type individuals_upload_path: str
+        :param automated_analysis_dir: Directory in the Drive service account's "Shared with Me" directory to upload the
+                                    automated analysis files from this pipeline run to.
+        :type automated_analysis_dir: str
+        """
+        self.drive_credentials_file_url = drive_credentials_file_url
+        self.production_upload_path = production_upload_path
+        self.messages_upload_path = messages_upload_path
+        self.individuals_upload_path = individuals_upload_path
+        self.automated_analysis_dir = automated_analysis_dir
+
+        self.validate()
+
+    @classmethod
+    def from_configuration_dict(cls, configuration_dict):
+        drive_credentials_file_url = configuration_dict["DriveCredentialsFileURL"]
+        production_upload_path = configuration_dict["ProductionUploadPath"]
+        messages_upload_path = configuration_dict["MessagesUploadPath"]
+        individuals_upload_path = configuration_dict["IndividualsUploadPath"]
+        analysis_graphs_dir = configuration_dict["AutomatedAnalysisDir"]
+
+        return cls(drive_credentials_file_url, production_upload_path, messages_upload_path,
+                   individuals_upload_path, analysis_graphs_dir)
+
+    def validate(self):
+        validators.validate_string(self.drive_credentials_file_url, "drive_credentials_file_url")
+        assert urlparse(self.drive_credentials_file_url).scheme == "gs", "DriveCredentialsFileURL needs to be a gs " \
+                                                                         "URL (i.e. of the form gs://bucket-name/file)"
+
+        validators.validate_string(self.production_upload_path, "production_upload_path")
+        validators.validate_string(self.messages_upload_path, "messages_upload_path")
+        validators.validate_string(self.individuals_upload_path, "individuals_upload_path")
+        validators.validate_string(self.automated_analysis_dir, "automated_analysis_dir")


### PR DESCRIPTION
This adds all the pipeline configurations. Currently loads episode 1 for each camp but the project has 10 episodes in total. 
Uses keep_ii pipeline configuration design with a few changes to refer to AutomatedAnalysisDir instead of AnalysisGraphsDir will update to the recent design in a future pr.
