### PR TITLE
Export safe to share messages

### DIFF
--- a/automated_analysis.py
+++ b/automated_analysis.py
@@ -485,7 +485,7 @@ if __name__ == "__main__":
                 else:
                     no_of_dns_messages += 1
 
-            log.info(f"Excluding {dns_messages} unsafe to share messages")
+            log.info(f"Excluding {no_of_dns_messages} unsafe to share messages")
             for code_string_value in code_to_messages:
                 for msg in code_to_messages[code_string_value]:
                     safe_to_share_messages.append({

--- a/automated_analysis.py
+++ b/automated_analysis.py
@@ -461,10 +461,11 @@ if __name__ == "__main__":
                         scale=IMG_SCALE_FACTOR)
 
     # Export safe to share raw messages for each episode to share with WUSC
+    # Messages are safe to share if they have been reviewed and do not contain a 'DNS' (do not share) label
     log.info("Exporting safe to share raw messages for each episode...")
     safe_to_share_messages = []  # of dict of code_string_value to raw messages
     no_of_dns_messages = 0
-    for plan in PipelineConfiguration.RQA_CODING_PLANS[5:]: #loop through episode 6 -> because previous episodes had been manually processed
+    for plan in PipelineConfiguration.RQA_CODING_PLANS[5:]: # Loop through episode 6 -> because previous episodes had been manually processed
         for cc in plan.coding_configurations:
             code_to_messages = OrderedDict()
             for code in cc.code_scheme.codes:

--- a/automated_analysis.py
+++ b/automated_analysis.py
@@ -459,29 +459,34 @@ if __name__ == "__main__":
         fig.update_xaxes(tickangle=-60)
         fig.write_image(f"{automated_analysis_output_dir}/graphs/{plan.raw_field}_by_gender_normalised.png",
                         scale=IMG_SCALE_FACTOR)
-    
+
     # Export safe to share raw messages for each episode to share with WUSC
     log.info("Exporting safe to share raw messages for each episode...")
-    safe_to_share_messages = []  # of dict
+    safe_to_share_messages = []  # of dict of code_string_value to raw messages
     for plan in PipelineConfiguration.RQA_CODING_PLANS[5:]: #loop through episode 6 -> because previous episodes had been manually processed
         for cc in plan.coding_configurations:
-            code_to_messages = dict()
+            code_to_messages = OrderedDict()
             for code in cc.code_scheme.codes:
                 code_to_messages[code.string_value] = []
 
+            no_of_dns_messages = 0
             for msg in messages:
                 if not AnalysisUtils.opt_in(msg, CONSENT_WITHDRAWN_KEY, plan):
                     continue
 
+                code_string_values = set()
                 for label in msg[cc.coded_field]:
                     code = cc.code_scheme.get_code_with_code_id(label["CodeID"])
-                    code_to_messages[code.string_value].append(msg[plan.raw_field])
+                    code_string_values.add(code.string_value)
 
+                if "dns" not in code_string_values:
+                    for code_string_value in code_string_values:
+                        code_to_messages[code_string_value].append(msg[plan.raw_field])
+                else:
+                    no_of_dns_messages += 1
+
+            log.info(f"Excluding {dns_messages} unsafe to share messages")
             for code_string_value in code_to_messages:
-                if code_string_value == "DNS": # TODO add DNS control code to core and update here
-                    log.warning(f"Excluding {len(code_to_messages[code_string_value])} unsafe to share messages")
-                    continue
-
                 for msg in code_to_messages[code_string_value]:
                     safe_to_share_messages.append({
                         "Episode": plan.dataset_name,
@@ -489,7 +494,7 @@ if __name__ == "__main__":
                         "Raw Message": msg
                     })
 
-    with open(f"{automated_analysis_output_dir}/wusc_safe_to_share_messages.csv", "w") as f:
+    with open(f"{automated_analysis_output_dir}/safe_to_share_messages.csv", "w") as f:
         headers = ["Episode", "Code", "Raw Message"]
         writer = csv.DictWriter(f, fieldnames=headers, lineterminator="\n")
         writer.writeheader()

--- a/automated_analysis.py
+++ b/automated_analysis.py
@@ -484,7 +484,7 @@ if __name__ == "__main__":
 
                 for msg in code_to_messages[code_string_value]:
                     safe_to_share_messages.append({
-                        plan.dataset_name: msg,
+                        "Episode": plan.dataset_name,
                         "Code": code_string_value,
                         "Raw Message": msg
                     })

--- a/automated_analysis.py
+++ b/automated_analysis.py
@@ -479,7 +479,7 @@ if __name__ == "__main__":
                     code = cc.code_scheme.get_code_with_code_id(label["CodeID"])
                     code_string_values.add(code.string_value)
 
-                if "dns" not in code_string_values:
+                if "DNS" not in code_string_values:
                     for code_string_value in code_string_values:
                         code_to_messages[code_string_value].append(msg[plan.raw_field])
                 else:

--- a/automated_analysis.py
+++ b/automated_analysis.py
@@ -463,15 +463,15 @@ if __name__ == "__main__":
     # Export safe to share raw messages for each episode to share with WUSC
     log.info("Exporting safe to share raw messages for each episode...")
     safe_to_share_messages = []  # of dict of code_string_value to raw messages
+    no_of_dns_messages = 0
     for plan in PipelineConfiguration.RQA_CODING_PLANS[5:]: #loop through episode 6 -> because previous episodes had been manually processed
         for cc in plan.coding_configurations:
             code_to_messages = OrderedDict()
             for code in cc.code_scheme.codes:
                 code_to_messages[code.string_value] = []
 
-            no_of_dns_messages = 0
             for msg in messages:
-                if not AnalysisUtils.opt_in(msg, CONSENT_WITHDRAWN_KEY, plan):
+                if not AnalysisUtils.labelled(msg, CONSENT_WITHDRAWN_KEY, plan):
                     continue
 
                 code_string_values = set()
@@ -485,7 +485,6 @@ if __name__ == "__main__":
                 else:
                     no_of_dns_messages += 1
 
-            log.info(f"Excluding {no_of_dns_messages} unsafe to share messages")
             for code_string_value in code_to_messages:
                 for msg in code_to_messages[code_string_value]:
                     safe_to_share_messages.append({
@@ -493,6 +492,8 @@ if __name__ == "__main__":
                         "Code": code_string_value,
                         "Raw Message": msg
                     })
+
+    log.info(f"Excluded {no_of_dns_messages} unsafe to share messages")
 
     with open(f"{automated_analysis_output_dir}/safe_to_share_messages.csv", "w") as f:
         headers = ["Episode", "Code", "Raw Message"]

--- a/code_schemes/kakuma_s01e06.json
+++ b/code_schemes/kakuma_s01e06.json
@@ -85,16 +85,6 @@
       "VisibleInCoda": false
     },
     {
-      "CodeID": "code-DNS-982f3ca2",
-      "CodeType": "Control",
-      "ControlCode": "DNS",
-      "DisplayText": "DNS (do not share)",
-      "NumericValue": -120,
-      "StringValue": "DNS",
-      "Shortcut": "d",
-      "VisibleInCoda": true
-    },
-    {
       "CodeID": "code-PB-a434a800",
       "CodeType": "Meta",
       "MetaCode": "push_back",
@@ -155,6 +145,15 @@
       "DisplayText": "meta: participation incentive",
       "NumericValue": -100060,
       "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-DNS-982f3ca2",
+      "DisplayText": "meta: DNS (do not share)",
+      "CodeType": "Meta",
+      "MetaCode": "dns",
+      "StringValue": "dns",
+      "NumericValue": -100070,
       "VisibleInCoda": true
     }
   ]

--- a/code_schemes/kakuma_s01e06.json
+++ b/code_schemes/kakuma_s01e06.json
@@ -85,6 +85,15 @@
       "VisibleInCoda": false
     },
     {
+      "CodeID": "code-DNS-982f3ca2",
+      "CodeType": "Control",
+      "ControlCode": "DNS",
+      "DisplayText": "DNS (do not share)",
+      "NumericValue": -120,
+      "StringValue": "DNS",
+      "VisibleInCoda": true
+    },
+    {
       "CodeID": "code-PB-a434a800",
       "CodeType": "Meta",
       "MetaCode": "push_back",
@@ -145,15 +154,6 @@
       "DisplayText": "meta: participation incentive",
       "NumericValue": -100060,
       "StringValue": "participation_incentive",
-      "VisibleInCoda": true
-    },
-    {
-      "CodeID": "code-DNS-982f3ca2",
-      "DisplayText": "meta: DNS (do not share)",
-      "CodeType": "Meta",
-      "MetaCode": "dns",
-      "StringValue": "dns",
-      "NumericValue": -100070,
       "VisibleInCoda": true
     }
   ]

--- a/code_schemes/kakuma_s01e06.json
+++ b/code_schemes/kakuma_s01e06.json
@@ -85,6 +85,16 @@
       "VisibleInCoda": false
     },
     {
+      "CodeID": "code-DNS-982f3ca2",
+      "CodeType": "Control",
+      "ControlCode": "DNS",
+      "DisplayText": "DNS (do not share)",
+      "NumericValue": -120,
+      "StringValue": "DNS",
+      "Shortcut": "d",
+      "VisibleInCoda": true
+    },
+    {
       "CodeID": "code-PB-a434a800",
       "CodeType": "Meta",
       "MetaCode": "push_back",

--- a/code_schemes/kakuma_s01e07.json
+++ b/code_schemes/kakuma_s01e07.json
@@ -85,16 +85,6 @@
       "VisibleInCoda": false
     },
     {
-      "CodeID": "code-DNS-982f3ca2",
-      "CodeType": "Control",
-      "ControlCode": "DNS",
-      "DisplayText": "DNS (do not share)",
-      "NumericValue": -120,
-      "StringValue": "DNS",
-      "Shortcut": "d",
-      "VisibleInCoda": true
-    },
-    {
       "CodeID": "code-PB-a434a800",
       "CodeType": "Meta",
       "MetaCode": "push_back",
@@ -155,6 +145,15 @@
       "DisplayText": "meta: participation incentive",
       "NumericValue": -100060,
       "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-DNS-982f3ca2",
+      "DisplayText": "meta: DNS (do not share)",
+      "CodeType": "Meta",
+      "MetaCode": "dns",
+      "StringValue": "dns",
+      "NumericValue": -100070,
       "VisibleInCoda": true
     }
   ]

--- a/code_schemes/kakuma_s01e07.json
+++ b/code_schemes/kakuma_s01e07.json
@@ -85,6 +85,15 @@
       "VisibleInCoda": false
     },
     {
+      "CodeID": "code-DNS-982f3ca2",
+      "CodeType": "Control",
+      "ControlCode": "DNS",
+      "DisplayText": "DNS (do not share)",
+      "NumericValue": -120,
+      "StringValue": "DNS",
+      "VisibleInCoda": true
+    },
+    {
       "CodeID": "code-PB-a434a800",
       "CodeType": "Meta",
       "MetaCode": "push_back",
@@ -145,15 +154,6 @@
       "DisplayText": "meta: participation incentive",
       "NumericValue": -100060,
       "StringValue": "participation_incentive",
-      "VisibleInCoda": true
-    },
-    {
-      "CodeID": "code-DNS-982f3ca2",
-      "DisplayText": "meta: DNS (do not share)",
-      "CodeType": "Meta",
-      "MetaCode": "dns",
-      "StringValue": "dns",
-      "NumericValue": -100070,
       "VisibleInCoda": true
     }
   ]

--- a/code_schemes/kakuma_s01e07.json
+++ b/code_schemes/kakuma_s01e07.json
@@ -85,6 +85,16 @@
       "VisibleInCoda": false
     },
     {
+      "CodeID": "code-DNS-982f3ca2",
+      "CodeType": "Control",
+      "ControlCode": "DNS",
+      "DisplayText": "DNS (do not share)",
+      "NumericValue": -120,
+      "StringValue": "DNS",
+      "Shortcut": "d",
+      "VisibleInCoda": true
+    },
+    {
       "CodeID": "code-PB-a434a800",
       "CodeType": "Meta",
       "MetaCode": "push_back",

--- a/code_schemes/kakuma_s01e08.json
+++ b/code_schemes/kakuma_s01e08.json
@@ -85,16 +85,6 @@
       "VisibleInCoda": false
     },
     {
-      "CodeID": "code-DNS-982f3ca2",
-      "CodeType": "Control",
-      "ControlCode": "DNS",
-      "DisplayText": "DNS (do not share)",
-      "NumericValue": -120,
-      "StringValue": "DNS",
-      "Shortcut": "d",
-      "VisibleInCoda": true
-    },
-    {
       "CodeID": "code-PB-a434a800",
       "CodeType": "Meta",
       "MetaCode": "push_back",

--- a/code_schemes/kakuma_s01e08.json
+++ b/code_schemes/kakuma_s01e08.json
@@ -85,6 +85,15 @@
       "VisibleInCoda": false
     },
     {
+      "CodeID": "code-DNS-982f3ca2",
+      "CodeType": "Control",
+      "ControlCode": "DNS",
+      "DisplayText": "DNS (do not share)",
+      "NumericValue": -120,
+      "StringValue": "DNS",
+      "VisibleInCoda": true
+    },
+    {
       "CodeID": "code-PB-a434a800",
       "CodeType": "Meta",
       "MetaCode": "push_back",
@@ -145,15 +154,6 @@
       "DisplayText": "meta: participation incentive",
       "NumericValue": -100060,
       "StringValue": "participation_incentive",
-      "VisibleInCoda": true
-    },
-    {
-      "CodeID": "code-DNS-982f3ca2",
-      "DisplayText": "meta: DNS (do not share)",
-      "CodeType": "Meta",
-      "MetaCode": "dns",
-      "StringValue": "dns",
-      "NumericValue": -100070,
       "VisibleInCoda": true
     }
   ]

--- a/code_schemes/kakuma_s01e08.json
+++ b/code_schemes/kakuma_s01e08.json
@@ -85,6 +85,16 @@
       "VisibleInCoda": false
     },
     {
+      "CodeID": "code-DNS-982f3ca2",
+      "CodeType": "Control",
+      "ControlCode": "DNS",
+      "DisplayText": "DNS (do not share)",
+      "NumericValue": -120,
+      "StringValue": "DNS",
+      "Shortcut": "d",
+      "VisibleInCoda": true
+    },
+    {
       "CodeID": "code-PB-a434a800",
       "CodeType": "Meta",
       "MetaCode": "push_back",

--- a/code_schemes/kakuma_s01e08.json
+++ b/code_schemes/kakuma_s01e08.json
@@ -156,6 +156,15 @@
       "NumericValue": -100060,
       "StringValue": "participation_incentive",
       "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-DNS-982f3ca2",
+      "DisplayText": "meta: DNS (do not share)",
+      "CodeType": "Meta",
+      "MetaCode": "dns",
+      "StringValue": "dns",
+      "NumericValue": -100070,
+      "VisibleInCoda": true
     }
   ]
 }

--- a/code_schemes/kakuma_s01e09.json
+++ b/code_schemes/kakuma_s01e09.json
@@ -85,16 +85,6 @@
       "VisibleInCoda": false
     },
     {
-      "CodeID": "code-DNS-982f3ca2",
-      "CodeType": "Control",
-      "ControlCode": "DNS",
-      "DisplayText": "DNS (do not share)",
-      "NumericValue": -120,
-      "StringValue": "DNS",
-      "Shortcut": "d",
-      "VisibleInCoda": true
-    },
-    {
       "CodeID": "code-PB-a434a800",
       "CodeType": "Meta",
       "MetaCode": "push_back",
@@ -155,6 +145,15 @@
       "DisplayText": "meta: participation incentive",
       "NumericValue": -100060,
       "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-DNS-982f3ca2",
+      "DisplayText": "meta: DNS (do not share)",
+      "CodeType": "Meta",
+      "MetaCode": "dns",
+      "StringValue": "dns",
+      "NumericValue": -100070,
       "VisibleInCoda": true
     }
   ]

--- a/code_schemes/kakuma_s01e09.json
+++ b/code_schemes/kakuma_s01e09.json
@@ -85,6 +85,15 @@
       "VisibleInCoda": false
     },
     {
+      "CodeID": "code-DNS-982f3ca2",
+      "CodeType": "Control",
+      "ControlCode": "DNS",
+      "DisplayText": "DNS (do not share)",
+      "NumericValue": -120,
+      "StringValue": "DNS",
+      "VisibleInCoda": true
+    },
+    {
       "CodeID": "code-PB-a434a800",
       "CodeType": "Meta",
       "MetaCode": "push_back",
@@ -145,15 +154,6 @@
       "DisplayText": "meta: participation incentive",
       "NumericValue": -100060,
       "StringValue": "participation_incentive",
-      "VisibleInCoda": true
-    },
-    {
-      "CodeID": "code-DNS-982f3ca2",
-      "DisplayText": "meta: DNS (do not share)",
-      "CodeType": "Meta",
-      "MetaCode": "dns",
-      "StringValue": "dns",
-      "NumericValue": -100070,
       "VisibleInCoda": true
     }
   ]

--- a/code_schemes/kakuma_s01e09.json
+++ b/code_schemes/kakuma_s01e09.json
@@ -85,6 +85,16 @@
       "VisibleInCoda": false
     },
     {
+      "CodeID": "code-DNS-982f3ca2",
+      "CodeType": "Control",
+      "ControlCode": "DNS",
+      "DisplayText": "DNS (do not share)",
+      "NumericValue": -120,
+      "StringValue": "DNS",
+      "Shortcut": "d",
+      "VisibleInCoda": true
+    },
+    {
       "CodeID": "code-PB-a434a800",
       "CodeType": "Meta",
       "MetaCode": "push_back",

--- a/code_schemes/kakuma_s01e10.json
+++ b/code_schemes/kakuma_s01e10.json
@@ -1,5 +1,5 @@
 {
-  "SchemeID": "Scheme-f8a100a6",
+  "SchemeID": "Scheme-f8a100a63",
   "Name": "KAKUMA S01E10",
   "Version": "0.0.0.1",
   "Codes": [
@@ -84,16 +84,7 @@
       "StringValue": "CE",
       "VisibleInCoda": false
     },
-    {
-      "CodeID": "code-DNS-982f3ca2",
-      "CodeType": "Control",
-      "ControlCode": "DNS",
-      "DisplayText": "DNS (do not share)",
-      "NumericValue": -120,
-      "StringValue": "DNS",
-      "Shortcut": "d",
-      "VisibleInCoda": true
-    },
+
     {
       "CodeID": "code-PB-a434a800",
       "CodeType": "Meta",
@@ -155,6 +146,15 @@
       "DisplayText": "meta: participation incentive",
       "NumericValue": -100060,
       "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-DNS-982f3ca2",
+      "DisplayText": "meta: DNS (do not share)",
+      "CodeType": "Meta",
+      "MetaCode": "dns",
+      "StringValue": "dns",
+      "NumericValue": -100070,
       "VisibleInCoda": true
     }
   ]

--- a/code_schemes/kakuma_s01e10.json
+++ b/code_schemes/kakuma_s01e10.json
@@ -84,7 +84,6 @@
       "StringValue": "CE",
       "VisibleInCoda": false
     },
-
     {
       "CodeID": "code-PB-a434a800",
       "CodeType": "Meta",

--- a/code_schemes/kakuma_s01e10.json
+++ b/code_schemes/kakuma_s01e10.json
@@ -85,6 +85,15 @@
       "VisibleInCoda": false
     },
     {
+      "CodeID": "code-DNS-982f3ca2",
+      "CodeType": "Control",
+      "ControlCode": "DNS",
+      "DisplayText": "DNS (do not share)",
+      "NumericValue": -120,
+      "StringValue": "DNS",
+      "VisibleInCoda": true
+    },
+    {
       "CodeID": "code-PB-a434a800",
       "CodeType": "Meta",
       "MetaCode": "push_back",
@@ -145,15 +154,6 @@
       "DisplayText": "meta: participation incentive",
       "NumericValue": -100060,
       "StringValue": "participation_incentive",
-      "VisibleInCoda": true
-    },
-    {
-      "CodeID": "code-DNS-982f3ca2",
-      "DisplayText": "meta: DNS (do not share)",
-      "CodeType": "Meta",
-      "MetaCode": "dns",
-      "StringValue": "dns",
-      "NumericValue": -100070,
       "VisibleInCoda": true
     }
   ]

--- a/code_schemes/kakuma_s01e10.json
+++ b/code_schemes/kakuma_s01e10.json
@@ -85,6 +85,16 @@
       "VisibleInCoda": false
     },
     {
+      "CodeID": "code-DNS-982f3ca2",
+      "CodeType": "Control",
+      "ControlCode": "DNS",
+      "DisplayText": "DNS (do not share)",
+      "NumericValue": -120,
+      "StringValue": "DNS",
+      "Shortcut": "d",
+      "VisibleInCoda": true
+    },
+    {
       "CodeID": "code-PB-a434a800",
       "CodeType": "Meta",
       "MetaCode": "push_back",


### PR DESCRIPTION
WUSC has been requesting for raw messages after each episode before the labeling cycle is complete. We have been scanning through the messages manually to remove messages with sensitive data, however since we have shared the first report WUSC has agreed to wait for a week or two before we share the messages. This give us time to label DNS and export the messages + codes. 

This adopts the `DNS` theme from JPLG + modifies sample messages script to output an episode:Code: Message file that RDA can pull messages they want to share with WUSC. 

It picks up from episode 6 since the rest have already been shared. 